### PR TITLE
The atoms definition changed, made propeq_dec proof elegant.

### DIFF
--- a/Lang.v
+++ b/Lang.v
@@ -1,7 +1,7 @@
-Parameter atom : Set.
+Require Import Coq.Arith.Arith.
 
 Inductive prop : Type :=
-| Var : atom  -> prop
+| Var : nat  -> prop
 | Bot : prop
 | Top : prop
 | Zero : prop
@@ -25,17 +25,8 @@ Infix "⊃" := LDiv (right associativity, at level 54). (* 2283 *)
 Infix "⊂" := RDiv (right associativity, at level 55). (* 2282 *)
 Infix "⊗" := MCon (right associativity, at level 56). (* 2297 *)
 
-Axiom atomeq_dec : forall a b : atom, {a = b} + {a <> b}.
-
 Theorem propeq_dec : forall p q : prop, {p = q} + {p <> q}.
 Proof.
-  induction p; induction q;
-      try (left; reflexivity);
-      try (right; intros H; inversion H; contradiction H);
-      try (destruct (IHp1 q1); destruct (IHp2 q2); subst;
-        try (right; intros H; inversion H; contradiction n);
-        left; reflexivity).
-    destruct (atomeq_dec a a0).
-      - left. subst. reflexivity.
-      - right. intros H. inversion H. contradiction n.
+	decide equality.
+	apply eq_nat_dec.
 Qed.


### PR DESCRIPTION
It seems to me defining atoms as propositions indexed by natural numbers in the same inductive definition of `prop` is a better choice which simplifies everything (of course by assuming we have a countable set of atoms). For example the proof of propositions equality decidability reduces to natural numbers equality decidability which is provided in Coq.Arith module. If this minor change does not effect your further proofs very badly, you can merge this request.